### PR TITLE
Double slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 /composer.lock
 /bin/swagger

--- a/Readme.md
+++ b/Readme.md
@@ -102,3 +102,6 @@ For a more complete example have a look at the included Symfony Console command.
 
 ### v2.0.1
 * Update dependencies for ddesrosiers/silex-annotation-provider to the official 2.0 version
+
+### v2.0.2
+* Fix double slash being created using ````@Controller```` without a prefix

--- a/src/Silex/Swagger/Silex2SwaggerConverter.php
+++ b/src/Silex/Swagger/Silex2SwaggerConverter.php
@@ -200,7 +200,7 @@ class Silex2SwaggerConverter
         foreach (explode('|', $methods) as $method) {
             $method = trim($method);
             // for now we need this...
-            $path = '/'.$request->uri;
+            $path = str_replace('//', '/', '/'.$request->uri);
 
             $swgClass = 'Swagger\\Annotations\\'.ucfirst($method);
             /** @var SWG\Operation $swgOperation */


### PR DESCRIPTION
Fix issue where using ````@Controller``` without prefix would generate double slashes 